### PR TITLE
Clean up deprecated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Steps to get the project running
 * Install the requirements `cd src && pip install -r requirements.txt`
 * Set up testing requirements `pip install -r testing_requirements.txt`
 * Set up for development `python demotime/setup.py develop`
-* Create the db `python dt/manage.py syncdb && python dt/manage.py migrate`
+* Create the db `python dt/manage.py migrate`
 * Set up an administrator `python dt/manage.py createsuperuser`
 * Startup the server `python dt/manage.py runserver`
 * Optionally: `DT_URL=localhost:8008 python manage.py runserver 8008` to run on a different port and have emails still work fine

--- a/dt/dt/settings.py
+++ b/dt/dt/settings.py
@@ -91,21 +91,29 @@ USE_L10N = True
 
 USE_TZ = True
 
-
-# CUSTOM DJANGO SETTINGS
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.tz',
-    'django.core.context_processors.request',
-    'django.contrib.messages.context_processors.messages',
-    'demotime.context_processors.has_unread_messages',
-    'demotime.context_processors.unread_message_count',
-)
-
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            # insert your TEMPLATE_DIRS here
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.core.context_processors.debug',
+                'django.core.context_processors.i18n',
+                'django.core.context_processors.media',
+                'django.core.context_processors.static',
+                'django.core.context_processors.tz',
+                'django.core.context_processors.request',
+                'django.contrib.messages.context_processors.messages',
+                'demotime.context_processors.has_unread_messages',
+                'demotime.context_processors.unread_message_count',
+            ],
+        },
+    },
+]
 
 # MEDIA SETTINGS
 STATIC_URL = '/static/'


### PR DESCRIPTION
Deleted syncdb from README, as it is no longer used and was replaced with migrate; as well as changing the deprecated template structure in settings.py
